### PR TITLE
Laziest attempt at removing circular dependencies

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -1,6 +1,6 @@
 var THREE = require('three');
 
-exports.Viewport = function () {
+var Viewport = function () {
 	this.nearPlane = 0.1;
 	this.farPlane = 2000.0;
 	this.eyePosition = [0.0, 0.0, 0.0];
@@ -9,7 +9,7 @@ exports.Viewport = function () {
 	var _this = this;
 }
 
-exports.CameraControls = function ( object, domElement, renderer, scene ) {
+var CameraControls = function ( object, domElement, renderer, scene ) {
 	var _this = this;
 	var MODE = { NONE: -1, DEFAULT: 0, PATH: 1, SMOOTH_CAMERA_TRANSITION: 2, AUTO_TUMBLE: 3 };
 	var STATE = { NONE: -1, ROTATE: 0, ZOOM: 1, PAN: 2, TOUCH_ROTATE: 3, TOUCH_ZOOM: 4, TOUCH_PAN: 5, SCROLL: 6 };
@@ -40,7 +40,7 @@ exports.CameraControls = function ( object, domElement, renderer, scene ) {
 	var updateLightWithPathFlag = false;
 	var playRate = 500;
 	var deviceOrientationControl = undefined;
-	var defaultViewport = new Zinc.Viewport();
+	var defaultViewport = new Viewport();
 	var currentMode = MODE.DEFAULT;
 	var smoothCameraTransitionObject = undefined;
 	var cameraAutoTumbleObject = undefined;
@@ -653,7 +653,7 @@ exports.CameraControls = function ( object, domElement, renderer, scene ) {
 		{
 			localNearPlane = eye_distance - clip_distance;
 		}
-		var newViewport = new Zinc.Viewport();
+		var newViewport = new Viewport();
 		newViewport.nearPlane = localNearPlane;
 		newViewport.farPlane = localFarPlane;
 		newViewport.eyePosition = localEyePosition;
@@ -669,7 +669,7 @@ exports.CameraControls = function ( object, domElement, renderer, scene ) {
 	}
 	
 	this.getCurrentViewport = function() {
-		var currentViewport = new Zinc.Viewport();
+		var currentViewport = new Viewport();
 		currentViewport.nearPlane = _this.cameraObject.near;
 		currentViewport.farPlane = _this.cameraObject.far;
 		currentViewport.eyePosition[0] = _this.cameraObject.position.x;
@@ -693,7 +693,7 @@ exports.CameraControls = function ( object, domElement, renderer, scene ) {
 	}
 	
 	this.cameraTransition = function (startingViewport, endingViewport, durationIn) {
-		smoothCameraTransitionObject = new Zinc.SmoothCameraTransition(startingViewport, endingViewport,
+		smoothCameraTransitionObject = new SmoothCameraTransition(startingViewport, endingViewport,
 			_this, durationIn);
 	}
 	
@@ -715,7 +715,7 @@ exports.CameraControls = function ( object, domElement, renderer, scene ) {
 	}
 	
 	this.autoTumble = function (tumbleDirectionIn, tumbleRateIn, stopOnCameraInputIn) {
-		cameraAutoTumbleObject = new Zinc.CameraAutoTumble(tumbleDirectionIn, tumbleRateIn, stopOnCameraInputIn, _this);
+		cameraAutoTumbleObject = new CameraAutoTumble(tumbleDirectionIn, tumbleRateIn, stopOnCameraInputIn, _this);
 	}
 	
 	this.enableAutoTumble = function () {
@@ -729,7 +729,7 @@ exports.CameraControls = function ( object, domElement, renderer, scene ) {
 	
 	this.enableRaycaster = function (sceneIn, callbackFunctionIn, hoverCallbackFunctionIn) {
 		if (zincRayCaster == undefined)
-			zincRayCaster = new Zinc.RayCaster(sceneIn, callbackFunctionIn, hoverCallbackFunctionIn, _this.renderer);
+			zincRayCaster = new RayCaster(sceneIn, callbackFunctionIn, hoverCallbackFunctionIn, _this.renderer);
 	}
 	
 	this.disableRaycaster = function () {
@@ -750,7 +750,7 @@ exports.CameraControls = function ( object, domElement, renderer, scene ) {
 
 };
 
-exports.SmoothCameraTransition = function (startingViewport, endingViewport, targetCameraIn, durationIn) {
+var SmoothCameraTransition = function (startingViewport, endingViewport, targetCameraIn, durationIn) {
 	var startingEyePosition = startingViewport.eyePosition;
 	var startingTargetPosition = startingViewport.targetPosition;
 	var endingEyePosition = endingViewport.eyePosition;
@@ -804,7 +804,7 @@ exports.SmoothCameraTransition = function (startingViewport, endingViewport, tar
 	
 };
 
-exports.RayCaster = function (sceneIn, callbackFunctionIn, hoverCallbackFunctionIn, rendererIn) {
+var RayCaster = function (sceneIn, callbackFunctionIn, hoverCallbackFunctionIn, rendererIn) {
 	var scene = sceneIn;
 	var renderer = rendererIn;
 	var callbackFunction = callbackFunctionIn;
@@ -849,7 +849,7 @@ exports.RayCaster = function (sceneIn, callbackFunctionIn, hoverCallbackFunction
 };
 
 
-exports.CameraAutoTumble = function (tumbleDirectionIn, tumbleRateIn, stopOnCameraInputIn, targetCameraIn) {
+var CameraAutoTumble = function (tumbleDirectionIn, tumbleRateIn, stopOnCameraInputIn, targetCameraIn) {
 	var tumbleAxis = new THREE.Vector3();
 	var angle = -tumbleRateIn;
 	var targetCamera = targetCameraIn;
@@ -1011,7 +1011,7 @@ Object.assign( StereoCameraZoomFixed.prototype, {
  * @authod arodic / http://aleksandarrodic.com/
  * @authod fonserbc / http://fonserbc.github.io/
 */
-exports.StereoEffect = function ( renderer ) {
+var StereoEffect = function ( renderer ) {
 
 	var _stereo = new StereoCameraZoom();
 	_stereo.aspect = 0.5;
@@ -1161,3 +1161,10 @@ ModifiedDeviceOrientationControls = function ( object ) {
 	this.connect();
 
 };
+
+exports.Viewport = Viewport
+exports.CameraControls = CameraControls
+exports.SmoothCameraTransition = SmoothCameraTransition
+exports.RayCaster = RayCaster
+exports.CameraAutoTumble = CameraAutoTumble
+exports.StereoEffect = StereoEffect

--- a/src/glyphset.js
+++ b/src/glyphset.js
@@ -380,7 +380,7 @@ exports.Glyphset = function()  {
 	
 	var createGlyphs = function(geometry, material) {
 		for (var i = 0; i < numberOfVertices; i ++) {
-			var glyph = new Zinc.Glyph(geometry, material, i + 1);
+			var glyph = new (require('./glyph').Glyph)(geometry, material, i + 1);
 			glyphList[i] = glyph;
 			group.add(glyph.getMesh());
 		}

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -121,7 +121,7 @@ exports.Renderer = function (containerIn, window) {
 		if (sceneMap[name] != undefined){
 			return undefined;
 		} else {
-			var new_scene = new Zinc.Scene(container, renderer)
+			var new_scene = new (require('./scene')).Scene(container, renderer)
 			sceneMap[name] = new_scene;
 			new_scene.sceneName = name;
 			return new_scene;

--- a/src/scene.js
+++ b/src/scene.js
@@ -1,4 +1,5 @@
 var THREE = require('three');
+var Zinc = require('./zinc');
 
 /**
  * A Zinc.Scene contains {@link Zinc.Geometry}, {@link Zinc.Glyphset} and 
@@ -100,7 +101,7 @@ exports.Scene = function ( containerIn, rendererIn) {
 		_this.directionalLight = new THREE.DirectionalLight( 0x777777  );
 		scene.add( _this.directionalLight );
 
-		zincCameraControls = new Zinc.CameraControls( _this.camera, rendererIn.domElement, rendererIn, scene );
+		zincCameraControls = new (require('./controls').CameraControls)( _this.camera, rendererIn.domElement, rendererIn, scene );
 
 		zincCameraControls.setDirectionalLight(_this.directionalLight);
 		zincCameraControls.resetView();
@@ -132,7 +133,7 @@ exports.Scene = function ( containerIn, rendererIn) {
 	 */
 	this.loadView = function(viewData)
 	{
-		var viewPort = new Zinc.Viewport();
+		var viewPort = new (require('./controls').Viewport)();
 		viewPort.nearPlane = viewData.nearPlane;
 		viewPort.farPlane = viewData.farPlane;
 		viewPort.eyePosition = viewData.eyePosition;
@@ -255,7 +256,7 @@ exports.Scene = function ( containerIn, rendererIn) {
 	//Load a glyphset into this scene.
 	var loadGlyphset = function(glyphsetData, glyphurl, groupName, finishCallback)
 	{
-		var newGlyphset = new Zinc.Glyphset();
+		var newGlyphset = new (require('./controls').Glyphset)();
         newGlyphset.duration = 3000;
         newGlyphset.load(glyphsetData, glyphurl, finishCallback);
         newGlyphset.groupName = groupName;
@@ -500,7 +501,7 @@ exports.Scene = function ( containerIn, rendererIn) {
 	
 	//Internal function for creating a Zinc.Geometry object and add it into the scene for rendering.
 	var addMeshToZincGeometry = function(mesh, modelId, localTimeEnabled, localMorphColour) {
-		var newGeometry = new Zinc.Geometry();
+		var newGeometry = new (require('./geometry').Geometry)();
 		scene.add( mesh );
 		var mixer = new THREE.AnimationMixer(mesh);
 		var clipAction = undefined;


### PR DESCRIPTION
Should also really turn the zinc module to provide an actual instance object so that there wouldn't be a global default colour/constants that would traverse through different rendering instances. Note that `scene` imports `zinc` which then imports `scene`, as the only circular dependency that remains (which results in `Zinc.Scene` to be undefined).