### PR TITLE
Update webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   "homepage": "http://alan-wu.github.io/ZincJS/",
   "devDependencies": {
     "uglifyjs-webpack-plugin": "^1.2.5",
-    "webpack": "^4.6.0",
-    "webpack-cli": "^2.1.2"
+    "webpack": "^4.20.2",
+    "webpack-cli": "^3.1.1"
   },
   "dependencies": {
     "three": "^0.92.0",


### PR DESCRIPTION
This prevents the following error when building:

`TypeError: Cannot read property 'properties' of undefined`