### PR TITLE
Keyboard event listener

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -402,8 +402,8 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 		const len = event.touches.length;
 		if (len == 1) {
 			this._state = STATE.TOUCH_ROTATE;
-			this.pointer_x = event.touches[0].clientX - rect.left;
-			this.pointer_y = event.touches[0].clientY - rect.top;
+			this.pointer_x = event.touches[0].clientX - rect?.left;
+			this.pointer_y = event.touches[0].clientY - rect?.top;
 			this.pointer_x_start = this.pointer_x;
 			this.pointer_y_start = this.pointer_y;
 			this.previous_pointer_x = this.pointer_x;
@@ -416,8 +416,8 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 		} else if (len == 3) {
 			this._state = STATE.TOUCH_PAN;
 			this.targetTouchId = event.touches[0].identifier;
-			this.pointer_x = event.touches[0].clientX - rect.left;
-			this.pointer_y = event.touches[0].clientY - rect.top;
+			this.pointer_x = event.touches[0].clientX - rect?.left;
+			this.pointer_y = event.touches[0].clientY - rect?.top;
 			this.previous_pointer_x = this.pointer_x;
 			this.previous_pointer_y= this.pointer_y;			
 		}
@@ -495,13 +495,13 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 
 	const onDocumentKeydownEvent = event => {
 		updateRect(false);
+		let changes = 0;
 		if (
 			(event.keyCode === KEYBOARD.EQUAL) ||
 			(event.keyCode === KEYBOARD.MINUS)
 		) {
 			this._state = STATE.KEYBOARD_ZOOM
 			let unit = 1;
-			let changes = 0;
 			if (event.shiftKey) {
 				unit = unit * 2
 			}
@@ -511,14 +511,12 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 				changes = this.zoomRate * unit;
 			}
 			zoomSize = zoomSize + changes;
-			event.preventDefault();
 		} else if (
 			(event.keyCode === KEYBOARD.ARROWLEFT) ||
 			(event.keyCode === KEYBOARD.ARROWUP) ||
 			(event.keyCode === KEYBOARD.ARROWRIGHT) ||
 			(event.keyCode === KEYBOARD.ARROWDOWN)
 		) {
-			let changes = 0;
 			if (event.shiftKey) {
 				this._state = STATE.KEYBOARD_ROTATE
 				this.pointer_x_start = this.pointer_x;
@@ -626,8 +624,8 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 	const tumble = () => {
 		if (typeof this.cameraObject !== "undefined")
 		{
-			const width = rect.width;
-			const height = rect.height;
+			const width = rect?.width;
+			const height = rect?.height;
 			if ((0<width)&&(0<height))
 			{
 				const radius=0.25*(width+height);

--- a/src/controls.js
+++ b/src/controls.js
@@ -46,7 +46,7 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
    */
 	const STATE = { NONE: -1, ROTATE: 0, ZOOM: 1, PAN: 2, TOUCH_ROTATE: 3, TOUCH_ZOOM: 4, TOUCH_PAN: 5, SCROLL: 6, KEYBOARD_ZOOM: 7, KEYBOARD_ROTATE: 8, KEYBOARD_PAN: 9 };
   const ROTATE_DIRECTION = { NONE: -1, FREE: 1, HORIZONTAL: 2, VERTICAL: 3 };
-	const KEYBOARD = { ARROWLEFT: 37, ARROWUP: 38, ARROWRIGHT: 39, ARROWDOWN: 40, EQUAL: 187, MINUS: 189 };
+	const KEYBOARD = { ARROWLEFT: 37, ARROWUP: 38, ARROWRIGHT: 39, ARROWDOWN: 40, NUMPADADD: 107, NUMPADSUBTRACT: 109, EQUAL: 187, MINUS: 189 };
   /** 
    * Available click actions are MAIN, AUXILIARY and SECONARY.
    * @property {Object} 
@@ -498,16 +498,24 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 		let changes = 0;
 		if (
 			(event.keyCode === KEYBOARD.EQUAL) ||
-			(event.keyCode === KEYBOARD.MINUS)
+			(event.keyCode === KEYBOARD.MINUS) ||
+			(event.keyCode === KEYBOARD.NUMPADADD) ||
+			(event.keyCode === KEYBOARD.NUMPADSUBTRACT)
 		) {
 			this._state = STATE.KEYBOARD_ZOOM
 			let unit = 1;
 			if (event.shiftKey) {
 				unit = unit * 2
 			}
-			if (event.keyCode === KEYBOARD.EQUAL) {
+			if (
+				(event.keyCode === KEYBOARD.EQUAL) ||
+				(event.keyCode === KEYBOARD.NUMPADADD)
+			) {
 				changes = this.zoomRate * unit * -1;
-			} else {
+			} else if (
+				(event.keyCode === KEYBOARD.MINUS) ||
+				(event.keyCode === KEYBOARD.NUMPADSUBTRACT)
+			) {
 				changes = this.zoomRate * unit;
 			}
 			zoomSize = zoomSize + changes;

--- a/src/controls.js
+++ b/src/controls.js
@@ -71,6 +71,7 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 	this.touchZoomDistanceEnd = 0;
 	this.directionalLight = 0;
 	this.zoomRate = 50;
+	this.panRate = 100;
 	this.pixelHeight = 1;
 	let duration = 6000;
   let enabled = true;
@@ -510,6 +511,24 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 			}
 			zoomSize = zoomSize + changes;
 			event.preventDefault();
+		} else if (
+			(event.keyCode === KEYBOARD.ARROWLEFT) ||
+			(event.keyCode === KEYBOARD.ARROWUP) ||
+			(event.keyCode === KEYBOARD.ARROWRIGHT) ||
+			(event.keyCode === KEYBOARD.ARROWDOWN)
+		) {
+			this._state = STATE.KEYBOARD_PAN
+			this.previous_pointer_x = this.pointer_x;
+			this.previous_pointer_y = this.pointer_y;
+			if (event.keyCode === KEYBOARD.ARROWLEFT) {
+				this.pointer_x = this.pointer_x + this.panRate - rect.left;
+			} else if (event.keyCode === KEYBOARD.ARROWUP) {
+				this.pointer_y = this.pointer_y + this.panRate - rect.left;
+			} else if (event.keyCode === KEYBOARD.ARROWRIGHT) {
+				this.pointer_x = this.pointer_x - this.panRate - rect.top;
+			} else if (event.keyCode === KEYBOARD.ARROWDOWN) {
+				this.pointer_y = this.pointer_y - this.panRate - rect.top;
+			}
 		}
 	}
 
@@ -979,7 +998,7 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
     if ((this._state === STATE.ROTATE) || (this._state === STATE.TOUCH_ROTATE)){
       //rotateion does not trigger callback
       tumble();
-    } else if ((this._state === STATE.PAN) || (this._state === STATE.TOUCH_PAN)){
+    } else if ((this._state === STATE.PAN) || (this._state === STATE.TOUCH_PAN) || (this._state === STATE.KEYBOARD_PAN)){
       translate();
       ndcControl.triggerCallback();
     } else if ((this._state === STATE.ZOOM) || (this._state === STATE.TOUCH_ZOOM) || (this._state === STATE.SCROLL) || (this._state === STATE.KEYBOARD_ZOOM)){
@@ -1033,7 +1052,7 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 			}
 			if ((this._state === STATE.ROTATE) || (this._state === STATE.TOUCH_ROTATE)){
 				tumble();
-			} else if ((this._state === STATE.PAN) || (this._state === STATE.TOUCH_PAN)){
+			} else if ((this._state === STATE.PAN) || (this._state === STATE.TOUCH_PAN) || (this._state === STATE.KEYBOARD_PAN)){
 				translate();
 			} else if ((this._state === STATE.ZOOM) || (this._state === STATE.TOUCH_ZOOM) || (this._state === STATE.SCROLL) || (this._state === STATE.KEYBOARD_ZOOM)){
 				flyZoom();

--- a/src/controls.js
+++ b/src/controls.js
@@ -71,6 +71,7 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 	this.touchZoomDistanceEnd = 0;
 	this.directionalLight = 0;
 	this.zoomRate = 50;
+	this.rotateRate = 50;
 	this.panRate = 100;
 	this.pixelHeight = 1;
 	let duration = 6000;
@@ -517,17 +518,26 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 			(event.keyCode === KEYBOARD.ARROWRIGHT) ||
 			(event.keyCode === KEYBOARD.ARROWDOWN)
 		) {
-			this._state = STATE.KEYBOARD_PAN
+			let changes = 0;
+			if (event.shiftKey) {
+				this._state = STATE.KEYBOARD_ROTATE
+				this.pointer_x_start = this.pointer_x;
+				this.pointer_y_start = this.pointer_y;
+				changes = this.rotateRate
+			} else {
+				this._state = STATE.KEYBOARD_PAN
+				changes = this.panRate
+			}
 			this.previous_pointer_x = this.pointer_x;
 			this.previous_pointer_y = this.pointer_y;
 			if (event.keyCode === KEYBOARD.ARROWLEFT) {
-				this.pointer_x = this.pointer_x + this.panRate - rect.left;
+				this.pointer_x = this.pointer_x + changes - rect.left;
 			} else if (event.keyCode === KEYBOARD.ARROWUP) {
-				this.pointer_y = this.pointer_y + this.panRate - rect.left;
+				this.pointer_y = this.pointer_y + changes - rect.left;
 			} else if (event.keyCode === KEYBOARD.ARROWRIGHT) {
-				this.pointer_x = this.pointer_x - this.panRate - rect.top;
+				this.pointer_x = this.pointer_x - changes - rect.top;
 			} else if (event.keyCode === KEYBOARD.ARROWDOWN) {
-				this.pointer_y = this.pointer_y - this.panRate - rect.top;
+				this.pointer_y = this.pointer_y - changes - rect.top;
 			}
 		}
 	}
@@ -995,7 +1005,7 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 
   // handle synchronised control based on information in the idc
   const handleSyncControl = () => {
-    if ((this._state === STATE.ROTATE) || (this._state === STATE.TOUCH_ROTATE)){
+    if ((this._state === STATE.ROTATE) || (this._state === STATE.TOUCH_ROTATE) || (this._state === STATE.KEYBOARD_ROTATE)){
       //rotateion does not trigger callback
       tumble();
     } else if ((this._state === STATE.PAN) || (this._state === STATE.TOUCH_PAN) || (this._state === STATE.KEYBOARD_PAN)){
@@ -1050,7 +1060,7 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 			if (this._state !== STATE.NONE) {
 				updated = true;
 			}
-			if ((this._state === STATE.ROTATE) || (this._state === STATE.TOUCH_ROTATE)){
+			if ((this._state === STATE.ROTATE) || (this._state === STATE.TOUCH_ROTATE) || (this._state === STATE.KEYBOARD_ROTATE)){
 				tumble();
 			} else if ((this._state === STATE.PAN) || (this._state === STATE.TOUCH_PAN) || (this._state === STATE.KEYBOARD_PAN)){
 				translate();

--- a/src/controls.js
+++ b/src/controls.js
@@ -537,13 +537,13 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 			this.previous_pointer_x = this.pointer_x;
 			this.previous_pointer_y = this.pointer_y;
 			if (event.keyCode === KEYBOARD.ARROWLEFT) {
-				this.pointer_x = this.pointer_x + changes - rect.left;
+				this.pointer_x = this.pointer_x - changes - rect.left;
 			} else if (event.keyCode === KEYBOARD.ARROWUP) {
-				this.pointer_y = this.pointer_y + changes - rect.left;
+				this.pointer_y = this.pointer_y - changes - rect.left;
 			} else if (event.keyCode === KEYBOARD.ARROWRIGHT) {
-				this.pointer_x = this.pointer_x - changes - rect.top;
+				this.pointer_x = this.pointer_x + changes - rect.top;
 			} else if (event.keyCode === KEYBOARD.ARROWDOWN) {
-				this.pointer_y = this.pointer_y - changes - rect.top;
+				this.pointer_y = this.pointer_y + changes - rect.top;
 			}
 		}
 	}

--- a/src/controls.js
+++ b/src/controls.js
@@ -294,6 +294,16 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 		CLICK_ACTION[buttonName] = STATE[actionName];
   }
 
+	/**
+	 * 
+	 * @param {HTML} element 
+	 * @param {Number} index 
+	 */
+	const setCanvasTabindex = (element, index) => {
+		if (element instanceof HTMLCanvasElement)
+			element.tabIndex = index
+	}
+
   //Make sure the camera does not travel beyond limit
   const checkTravelDistance = () => {
     if (maxDist > 0) {
@@ -711,6 +721,7 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 	this.enable = function () {
 		enabled = true;
 		if (this.domElement && this.domElement.addEventListener) {
+			setCanvasTabindex(this.domElement, 1)
 			this.domElement.addEventListener( 'mousedown', onDocumentMouseDown, false );
 			this.domElement.addEventListener( 'mousemove', onDocumentMouseMove, false );
 			this.domElement.addEventListener( 'mouseup', onDocumentMouseUp, false );
@@ -740,6 +751,7 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 			this.domElement.removeEventListener( 'wheel', onDocumentWheelEvent, false);
       this.domElement.removeEventListener( 'mouseenter', onDocumentEnter, false );
 			this.domElement.removeEventListener( 'contextmenu', event => { event.preventDefault(); }, false );
+			setCanvasTabindex(this.domElement, -1)
 	    }
 	}
 


### PR DESCRIPTION
Added keyboard zoom, rotate and pan options. Need to click on the canvas first.

- -/=: Zoom by 1 level(50)
- Shift + _/+: Zoom by 2 level(100)
- Arrow keys: Pan by 100.
- Shift + arrow keys: Rotate by 50

Removed error message on touch mode.


https://github.com/user-attachments/assets/ef14edc0-af26-4739-96ba-c50f5891399e

