### PR TITLE
Display scaffolds in one of the six planes

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -106,6 +106,7 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
   let hasUpdated = false;
   let ndcControl = undefined;
   let maxDist = 0;
+  let planeAxis = undefined
   const viewports = {
     "default" : new Viewport()
   };
@@ -621,14 +622,30 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 	
 	/**
 	 * 
-	 * @param {*} axis - Either THREE.Vector3 object or three component array
+	 * @param {*} axis - THREE.Vector3 object, three component array or specified plane string
 	 */
 	this.alignCameraWithAxis = (axis) => {
-		if (axis instanceof THREE.Vector3 || Array.isArray(axis)) {
+		if (axis instanceof THREE.Vector3 || Array.isArray(axis) || typeof axis === "string") {
 			if (axis instanceof THREE.Vector3 && axis.length() > 0) {
 				_a.copy(axis).normalize();
 			} else if (Array.isArray(axis) && axis.length === 3) {
 				_a.fromArray(axis).normalize();
+			} else if (typeof axis === "string" && axis.trim().length > 0) {
+				if (!this.planeAxis) {
+					const quaternion = this.cameraObject.quaternion;
+					const front = new THREE.Vector3(0, 0, 1).applyQuaternion(quaternion);
+					const right = new THREE.Vector3(1, 0, 0).applyQuaternion(quaternion);
+					const up = new THREE.Vector3(0, 1, 0).applyQuaternion(quaternion);
+					this.planeAxis = {
+						front: front,
+						back: front.clone().negate(),
+						left: right.clone().negate(),
+						right: right,
+						up: up,
+						down: up.clone().negate()
+					}
+				}
+				_a.copy(this.planeAxis[axis]).normalize();
 			}
 			_v.copy(this.cameraObject.position).sub(this.cameraObject.target);
 			const mag = _v.length();
@@ -639,25 +656,6 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 			this.updateDirectionalLight();
 			this.cameraObject.updateProjectionMatrix();
 		}
-	}
-
-	/**
-	 * @returns - Plane axis that used to align Camera
-	 */
-	this.getPlaneAxis = () => {
-		const quaternion = this.cameraObject.quaternion;
-		const front = new THREE.Vector3(0, 0, 1).applyQuaternion(quaternion);
-		const right = new THREE.Vector3(1, 0, 0).applyQuaternion(quaternion);
-		const up = new THREE.Vector3(0, 1, 0).applyQuaternion(quaternion);
-		const planeAxis = {
-			front: front,
-			back: front.clone().negate(),
-			left: right.clone().negate(),
-			right: right,
-			up: up,
-			down: up.clone().negate()
-		}
-		return planeAxis
 	}
 
   /**

--- a/src/controls.js
+++ b/src/controls.js
@@ -639,8 +639,27 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 			this.updateDirectionalLight();
 			this.cameraObject.updateProjectionMatrix();
 		}
-}
-	
+	}
+
+	/**
+	 * @returns - Plane axis that used to align Camera
+	 */
+	this.getPlaneAxis = () => {
+		const quaternion = this.cameraObject.quaternion;
+		const front = new THREE.Vector3(0, 0, 1).applyQuaternion(quaternion);
+		const right = new THREE.Vector3(1, 0, 0).applyQuaternion(quaternion);
+		const up = new THREE.Vector3(0, 1, 0).applyQuaternion(quaternion);
+		const planeAxis = {
+			front: front,
+			back: front.clone().negate(),
+			left: right.clone().negate(),
+			right: right,
+			up: up,
+			down: up.clone().negate()
+		}
+		return planeAxis
+	}
+
   /**
    * Rotate around the axis with the amount specified by angle.
    * 

--- a/src/controls.js
+++ b/src/controls.js
@@ -619,9 +619,17 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 	    return {position: _v, up: _a};
 	}
 	
+	/**
+	 * 
+	 * @param {*} axis - Either THREE.Vector3 object or three component array
+	 */
 	this.alignCameraWithAxis = (axis) => {
-		if (axis.length() > 0) {
-			_a.copy(axis).normalize();
+		if (axis instanceof THREE.Vector3 || Array.isArray(axis)) {
+			if (axis instanceof THREE.Vector3 && axis.length() > 0) {
+				_a.copy(axis).normalize();
+			} else if (Array.isArray(axis) && axis.length === 3) {
+				_a.fromArray(axis).normalize();
+			}
 			_v.copy(this.cameraObject.position).sub(this.cameraObject.target);
 			const mag = _v.length();
 			_v.x = this.cameraObject.target.x + mag * _a.x;
@@ -629,7 +637,6 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 			_v.z = this.cameraObject.target.z + mag * _a.z;
 			this.cameraObject.position.copy(_v);
 			this.updateDirectionalLight();
-			console.log(_a)
 			this.cameraObject.updateProjectionMatrix();
 		}
 }

--- a/src/controls.js
+++ b/src/controls.js
@@ -617,6 +617,21 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 	    return {position: _v, up: _a};
 	}
 	
+	this.alignCameraWithAxis = (axis) => {
+		if (axis.length() > 0) {
+			_a.copy(axis).normalize();
+			_v.copy(this.cameraObject.position).sub(this.cameraObject.target);
+			const mag = _v.length();
+			_v.x = this.cameraObject.target.x + mag * _a.x;
+			_v.y = this.cameraObject.target.y + mag * _a.y;
+			_v.z = this.cameraObject.target.z + mag * _a.z;
+			this.cameraObject.position.copy(_v);
+			this.updateDirectionalLight();
+			console.log(_a)
+			this.cameraObject.updateProjectionMatrix();
+		}
+}
+	
   /**
    * Rotate around the axis with the amount specified by angle.
    * 

--- a/src/controls.js
+++ b/src/controls.js
@@ -106,7 +106,7 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
   let hasUpdated = false;
   let ndcControl = undefined;
   let maxDist = 0;
-  let planeAxis = undefined
+  let viewportPlaneAxes = undefined
   const viewports = {
     "default" : new Viewport()
   };
@@ -619,33 +619,13 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
             axis.z*upa+_new_b.z*upb+_new_c.z*upc);
 	    return {position: _v, up: _a};
 	}
-	
-	/**
-	 * 
-	 * @param {*} axis - THREE.Vector3 object, three component array or specified plane string
-	 */
+
 	this.alignCameraWithAxis = (axis) => {
-		if (axis instanceof THREE.Vector3 || Array.isArray(axis) || typeof axis === "string") {
+		if (axis instanceof THREE.Vector3 || Array.isArray(axis)) {
 			if (axis instanceof THREE.Vector3 && axis.length() > 0) {
 				_a.copy(axis).normalize();
 			} else if (Array.isArray(axis) && axis.length === 3) {
 				_a.fromArray(axis).normalize();
-			} else if (typeof axis === "string" && axis.trim().length > 0) {
-				if (!this.planeAxis) {
-					const quaternion = this.cameraObject.quaternion;
-					const front = new THREE.Vector3(0, 0, 1).applyQuaternion(quaternion);
-					const right = new THREE.Vector3(1, 0, 0).applyQuaternion(quaternion);
-					const up = new THREE.Vector3(0, 1, 0).applyQuaternion(quaternion);
-					this.planeAxis = {
-						front: front,
-						back: front.clone().negate(),
-						left: right.clone().negate(),
-						right: right,
-						up: up,
-						down: up.clone().negate()
-					}
-				}
-				_a.copy(this.planeAxis[axis]).normalize();
 			}
 			_v.copy(this.cameraObject.position).sub(this.cameraObject.target);
 			const mag = _v.length();
@@ -656,6 +636,33 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 			this.updateDirectionalLight();
 			this.cameraObject.updateProjectionMatrix();
 		}
+	}
+
+	this.alignCameraWithDirection = (direction) => {
+		if (typeof direction === "string" && direction.trim().length > 0) {
+			if (!viewportPlaneAxes) {
+				this.getViewportPlaneAxes();
+			}
+			this.alignCameraWithAxis(viewportPlaneAxes[direction]);
+		}
+	}
+
+	this.getViewportPlaneAxes = () => {
+		if (!viewportPlaneAxes) {			
+			const quaternion = this.cameraObject.quaternion;
+			const front = new THREE.Vector3(0, 0, 1).applyQuaternion(quaternion);
+			const right = new THREE.Vector3(1, 0, 0).applyQuaternion(quaternion);
+			const up = new THREE.Vector3(0, 1, 0).applyQuaternion(quaternion);
+			viewportPlaneAxes = {
+				front: front,
+				back: front.clone().negate(),
+				left: right.clone().negate(),
+				right: right,
+				up: up,
+				down: up.clone().negate()
+			}
+		}
+		return viewportPlaneAxes
 	}
 
   /**

--- a/src/controls.js
+++ b/src/controls.js
@@ -106,7 +106,7 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
   let hasUpdated = false;
   let ndcControl = undefined;
   let maxDist = 0;
-  let viewportPlaneAxes = undefined
+  let defaultPlaneAxes = undefined
   const viewports = {
     "default" : new Viewport()
   };
@@ -640,29 +640,28 @@ const CameraControls = function ( object, domElement, renderer, scene ) {
 
 	this.alignCameraWithDirection = (direction) => {
 		if (typeof direction === "string" && direction.trim().length > 0) {
-			if (!viewportPlaneAxes) {
-				this.getViewportPlaneAxes();
-			}
-			this.alignCameraWithAxis(viewportPlaneAxes[direction]);
+			if (!defaultPlaneAxes) return;
+			this.alignCameraWithAxis(defaultPlaneAxes[direction]);
 		}
 	}
 
 	this.getViewportPlaneAxes = () => {
-		if (!viewportPlaneAxes) {			
-			const quaternion = this.cameraObject.quaternion;
-			const front = new THREE.Vector3(0, 0, 1).applyQuaternion(quaternion);
-			const right = new THREE.Vector3(1, 0, 0).applyQuaternion(quaternion);
-			const up = new THREE.Vector3(0, 1, 0).applyQuaternion(quaternion);
-			viewportPlaneAxes = {
-				front: front,
-				back: front.clone().negate(),
-				left: right.clone().negate(),
-				right: right,
-				up: up,
-				down: up.clone().negate()
-			}
+		const quaternion = this.cameraObject.quaternion;
+		const front = new THREE.Vector3(0, 0, 1).applyQuaternion(quaternion);
+		const right = new THREE.Vector3(1, 0, 0).applyQuaternion(quaternion);
+		const up = new THREE.Vector3(0, 1, 0).applyQuaternion(quaternion);
+		const viewportPlaneAxes = {
+			front: front,
+			back: front.clone().negate(),
+			left: right.clone().negate(),
+			right: right,
+			up: up,
+			down: up.clone().negate()
 		}
-		return viewportPlaneAxes
+		if (!defaultPlaneAxes) {
+			defaultPlaneAxes = viewportPlaneAxes
+		}
+		return viewportPlaneAxes;
 	}
 
   /**


### PR DESCRIPTION
Because the x/y/z axis directions are not always consistent across different scaffolds. Using `[±1, 0, 0]/[0, ±1, 0]/[0, 0, ±1]` may get a unexpected rotation. (however `[±1, 0, 0]/[0, ±1, 0]/[0, 0, ±1]` are still allowed to be used to adjust the Camera.)

The actual (viewport-related) plane axis will be calculated when `front/back/right...` is passed as a param. The displayed plane after the scaffold is loaded will be the front plane.